### PR TITLE
base64: Wrap `BIO` objects in smart pointers, keep the check always enabled for DNSdist

### DIFF
--- a/pdns/base64.cc
+++ b/pdns/base64.cc
@@ -39,10 +39,10 @@ int B64Decode(const std::string& src, Container& dst)
     return 0;
   }
   // check if the dlen computation might overflow or it does not fit into an int (for IO_write)
-  if (src.length() > std::numeric_limits<size_t>::max() / 7 || src.length() > std::numeric_limits<int>::max()) {
+  if (src.length() > std::numeric_limits<size_t>::max() / 7U || src.length() > std::numeric_limits<int>::max()) {
     throw std::runtime_error("B64Decode too large");
   }
-  const size_t dlen = (src.length() * 6 + 7) / 8;
+  const size_t dlen = (src.length() * 6U + 7U) / 8U;
   dst.resize(dlen);
   auto bio = std::unique_ptr<BIO, void (*)(BIO*)>(BIO_new(BIO_s_mem()), BIO_free_all);
   if (!bio) {

--- a/pdns/base64.cc
+++ b/pdns/base64.cc
@@ -24,7 +24,9 @@
 
 #include "base64.hh"
 #include <limits>
+#include <memory>
 #include <stdexcept>
+
 #include <boost/scoped_array.hpp>
 #include <openssl/bio.h>
 #include <openssl/evp.h>
@@ -42,27 +44,24 @@ int B64Decode(const std::string& src, Container& dst)
   }
   const size_t dlen = (src.length() * 6 + 7) / 8;
   dst.resize(dlen);
-  BIO* bio = BIO_new(BIO_s_mem());
-  if (bio == nullptr) {
+  auto bio = std::unique_ptr<BIO, void (*)(BIO*)>(BIO_new(BIO_s_mem()), BIO_free_all);
+  if (!bio) {
     throw std::runtime_error("BIO_new failed");
   }
-  if (BIO_write(bio, src.c_str(), src.length()) != static_cast<int>(src.length())) {
-    BIO_free_all(bio);
+  if (BIO_write(bio.get(), src.c_str(), src.length()) != static_cast<int>(src.length())) {
     throw std::runtime_error("BIO_write failed");
   }
-  BIO* b64 = BIO_new(BIO_f_base64());
+  auto* b64 = BIO_new(BIO_f_base64());
   if (b64 == nullptr) {
-    BIO_free_all(bio);
     throw std::runtime_error("BIO_new failed");
   }
-  bio = BIO_push(b64, bio);
-  BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
+  bio = std::unique_ptr<BIO, void (*)(BIO*)>(BIO_push(b64, bio.release()), BIO_free_all);
+  BIO_set_flags(bio.get(), BIO_FLAGS_BASE64_NO_NL);
   auto olen = BIO_read(b64, &dst.at(0), dlen);
-  if ((olen == 0 || olen == -1) && BIO_should_retry(bio)) {
-    BIO_free_all(bio);
+  if ((olen == 0 || olen == -1) && BIO_should_retry(bio.get())) {
     throw std::runtime_error("BIO_read failed to read all data from memory buffer");
   }
-  BIO_free_all(bio);
+  bio.reset();
   if (olen > 0) {
     dst.resize(olen);
     return 0;
@@ -75,30 +74,28 @@ template int B64Decode<std::string>(const std::string& strInput, std::string& st
 std::string Base64Encode(const std::string& src)
 {
   if (!src.empty()) {
-    BIO* b64 = BIO_new(BIO_f_base64());
+    auto bio = std::unique_ptr<BIO, void (*)(BIO*)>(BIO_new(BIO_s_mem()), BIO_free_all);
+    if (!bio) {
+      throw std::runtime_error("BIO_new failed");
+    }
+    auto* b64 = BIO_new(BIO_f_base64());
     if (b64 == nullptr) {
       throw std::runtime_error("BIO_new failed");
     }
-    BIO* bio = BIO_new(BIO_s_mem());
-    if (bio == nullptr) {
-      BIO_free_all(b64);
-      throw std::runtime_error("BIO_new failed");
-    }
-    bio = BIO_push(b64, bio);
-    BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
-    int bioWriteRet = BIO_write(bio, src.c_str(), src.length());
+    bio = std::unique_ptr<BIO, void (*)(BIO*)>(BIO_push(b64, bio.release()), BIO_free_all);
+    BIO_set_flags(bio.get(), BIO_FLAGS_BASE64_NO_NL);
+    int bioWriteRet = BIO_write(bio.get(), src.c_str(), src.length());
     if (bioWriteRet < 0 || static_cast<size_t>(bioWriteRet) != src.length()) {
-      BIO_free_all(bio);
       throw std::runtime_error("BIO_write failed to write all data to memory buffer");
     }
-    (void)BIO_flush(bio);
+    (void)BIO_flush(bio.get());
     char* pp;
     std::string out;
-    auto olen = BIO_get_mem_data(bio, &pp);
+    auto olen = BIO_get_mem_data(bio.get(), &pp);
     if (olen > 0) {
       out = std::string(pp, olen);
     }
-    BIO_free_all(bio);
+    bio.reset();
     return out;
   }
   return "";

--- a/pdns/test-base64_cc.cc
+++ b/pdns/test-base64_cc.cc
@@ -82,7 +82,9 @@ BOOST_AUTO_TEST_CASE(test_Base64_Decode_Garbage)
   const std::string paddingOnly("====");
   std::string decoded;
   auto ret = B64Decode(paddingOnly, decoded);
-#if OPENSSL_VERSION_NUMBER >= 0x30500000
+  // DNSdist uses a custom base64 implementation,
+  // and older versions of OpenSSL were less strict
+#if defined(DNSDIST) || OPENSSL_VERSION_NUMBER >= 0x30500000
   BOOST_CHECK_EQUAL(ret, -1);
 #else
   // does not test anything meaningful, but avoids a "ret unused" warning


### PR DESCRIPTION
### Short description
<!-- Write a small description of what this Pull Request fixes or provides, including the issue #s -->

### Checklist
<!-- please indicate if any of these things are done/included with this Pull Request. Not all boxes need to be checked for the Pull Request to be accepted -->
I have:
- [x] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [x] read and accepted the [Developer Certificate of Origin](https://github.com/PowerDNS/pdns/blob/master/DCO) document, including the [AI Policy](https://github.com/PowerDNS/pdns/blob/master/AI_POLICY.md), and added a ["Signed-off-by"](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md#developer-certificate-of-origin) to my commits
- [x] compiled this code
- [x] tested this code
- [ ] included documentation (including possible behaviour changes)
- [x] documented the code
- [ ] added or modified regression test(s)
- [x] added or modified unit test(s)
